### PR TITLE
Add QGIS 4 compatibility metadata

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -5,29 +5,29 @@
 [general]
 name=Road Slope Calculator
 qgisMinimumVersion=3.14
+qgisMaximumVersion=4.99
 description=This algorithm is used to calculate the longitudinal slope of forest paths and roads, based on a 2D line vector layer and a DEM (Digital Elevation Model). It should not be used on national road systems, such as highways, motorways, national and regional roads, which have engineering works designed to smooth the slope (bridges, excavations, landfills, etc.), unless the user has access to a high precision Digital Surface Model (DSM).
-version=0.4
+version=0.5
 author=Antonio Sobral Almeida
 email=66124.almeida@gmail.com
 
 about=To run this plugin, go to Processing menu, open Toolbox window, and look for Road Slope -> Road slope calculator. For more (important) information, visit https://github.com/Almeida100/RSC.
 
-tracker=https://github.com/Almeida100/RSC/issues
-repository=https://github.com/Almeida100/RSC
+tracker=https://github.com/Almeida100/Road-Slope-Calculator/issues
+repository=https://github.com/Almeida100/Road-Slope-Calculator
 # End of mandatory metadata
 
 # Recommended items:
 
 hasProcessingProvider=yes
 # Uncomment the following line and add your changelog:
-# changelog=
+changelog=Added QGIS 4 compatibility metadata and cleaned up processing identifiers for QGIS 4 testing.
 
 # Tags are comma separated with spaces allowed
 tags=distance, geometry, line, processing, routing
 
-homepage=https://github.com/Almeida100
+homepage=https://github.com/Almeida100/Road-Slope-Calculator
 category=Analysis
-icon=icon.png
 # experimental flag
 experimental=False
 
@@ -39,7 +39,7 @@ deprecated=False
 # Check the documentation for more information.
 # plugin_dependencies=
 
-Category of the plugin: Raster, Vector, Database or Web
+# Category of the plugin: Raster, Vector, Database or Web
 # category=
 
 # If the plugin can run on QGIS Server.

--- a/road_slope_calculator_algorithm.py
+++ b/road_slope_calculator_algorithm.py
@@ -100,7 +100,7 @@ class RoadSlopeCalculatorAlgorithm(QgsProcessingAlgorithm):
             'INPUT': outputs['ExtractZValues']['OUTPUT'],
             'OUTPUT': QgsProcessing.TEMPORARY_OUTPUT
         }
-        outputs['FieldCalculator1'] = processing.run('qgis:fieldcalculator', alg_params, context=context, feedback=feedback, is_child_algorithm=True)
+        outputs['FieldCalculator1'] = processing.run('native:fieldcalculator', alg_params, context=context, feedback=feedback, is_child_algorithm=True)
 
         feedback.setCurrentStep(4)
         if feedback.isCanceled():
@@ -112,16 +112,16 @@ class RoadSlopeCalculatorAlgorithm(QgsProcessingAlgorithm):
             'FIELD_NAME': 'Slope_%',
             'FIELD_PRECISION': 3,
             'FIELD_TYPE': 0,
-            'FORMULA': '(abs(\"z_first\" - \"z_last\") / \"length\" ) *100',
+            'FORMULA': '(abs(\"z_first\" - \"z_last\") / \"Length\" ) *100',
             'INPUT': outputs['FieldCalculator1']['OUTPUT'],
             'OUTPUT': parameters['CalculatedRoadSlopes']
         }
-        outputs['FieldCalculator2'] = processing.run('qgis:fieldcalculator', alg_params, context=context, feedback=feedback, is_child_algorithm=True)
+        outputs['FieldCalculator2'] = processing.run('native:fieldcalculator', alg_params, context=context, feedback=feedback, is_child_algorithm=True)
         results['CalculatedRoadSlopes'] = outputs['FieldCalculator2']['OUTPUT']
         return results
 
     def name(self):
-        return 'Road slope calculator'
+        return 'road_slope_calculator'
 
     def displayName(self):
         return 'Road slope calculator'

--- a/road_slope_calculator_provider.py
+++ b/road_slope_calculator_provider.py
@@ -64,7 +64,7 @@ class RoadSlopeCalculatorProvider(QgsProcessingProvider):
         string should be a unique, short, character only string, eg "qgis" or
         "gdal". This string should not be localised.
         """
-        return 'Road slope'
+        return 'roadslopecalculator'
 
     def name(self):
         """


### PR DESCRIPTION
This PR updates the plugin for QGIS 4 compatibility.

Changes:
- add `qgisMaximumVersion=4.99` to `metadata.txt`
- bump plugin version to `0.5`
- clean up metadata links/comments
- switch field calculator calls to `native:fieldcalculator`
- normalize provider and algorithm IDs for QGIS 4

Validation:
- plugin provider loaded successfully under local QGIS 4.0.1
- registered algorithm id: `roadslopecalculator:road_slope_calculator`